### PR TITLE
Show connections without subscriptions (fixes #2 and #6)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -168,7 +168,7 @@ var app = function app() {
         content += '<td>' + val.in_msgs + ' / ' + val.out_msgs + '</td>';
         content += '<td>' + val.in_bytes + ' / ' + val.out_bytes + '</td>';
         content += '<td>' + val.subscriptions + '</td>';
-        content += '<td>' + val.subscriptions_list.join(', ') + '</td>';
+        content += '<td>' + (val.subscriptions_list ? val.subscriptions_list.join(', ') : '') + '</td>';
 
         content += '</tr>';
       }


### PR DESCRIPTION
Thanks for a great project!
Really easy to set up!

As it is now the connections tab is empty when there are connections without subscriptions (see #2 and #6).

This PR solves this!
