### PR TITLE
docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+Dockerfile
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM mhart/alpine-node:base
+
+WORKDIR /app
+COPY . .
+
+EXPOSE 3000
+EXPOSE 3001
+
+CMD ["bin/natsboard"]

--- a/bin/natsboard
+++ b/bin/natsboard
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
 
 require('..');
+
+process.on('SIGINT', function() {
+    process.exit();
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "2"
+
+services:
+  nats:
+    image: nats
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+
+  natsboard:
+    build: .
+    command: bin/natsboard --nats-mon-url http://nats:8222
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+    depends_on:
+      - nats


### PR DESCRIPTION
Added `Dockerfile` based on `mhart/alpine-node:base`, results smaller docker image (`~60MB`).
Also added a docker compose file, as an example for those who just like to run it in container, simply run `docker-compose up`.
