### PR TITLE
Run the Websockets on the same port

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -144,10 +144,17 @@ module.exports = function(app) {
         running = true;
         // Send data
         WS.clients.forEach(function(client) {
-          client.send(JSON.stringify({
-            type:  'rates',
-            rates: getRates()
-          }));
+          //If client state is 'OPEN'
+          if (client.readyState == 1) {
+            client.send(JSON.stringify({
+              type:  'rates',
+              rates: getRates()
+            }), function ack(error) {
+              if (error != null) {
+                console.log('Connection to client broken while sending data: %s', error.toString())
+              }
+            });
+          }
         });
         running = false;
       }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -143,8 +143,8 @@ module.exports = function(app) {
       if(!running) {
         running = true;
         // Send data
-        WS.connections.forEach(function(client) {
-          client.sendText(JSON.stringify({
+        WS.clients.forEach(function(client) {
+          client.send(JSON.stringify({
             type:  'rates',
             rates: getRates()
           }));

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,16 +6,19 @@
 /* jslint node: true, sub: true */
 'use strict';
 
+
+
+
 var express = require('express'),
     util    = require('util'),
     utilex  = require('utilex'),
-    ws      = require('nodejs-websocket'),
-    path    = require('path');
+    path    = require('path'),
+    http = require('http'),
+    WebSocket = require('ws');
 
 var ARGS         = utilex.args(),
     APP_PATH     = path.resolve(path.join(__dirname, '..')),
     NODE_PORT    = process.env.NODE_PORT    || ARGS['port']         || '3000',
-    NODE_PORTWS  = process.env.NODE_PORTWS  || ARGS['port-ws']      || parseInt(NODE_PORT)+1,
     NATS_MON_URL = process.env.NATS_MON_URL || ARGS['nats-mon-url'] || 'http://localhost:8222';
 
 // Handle errors - for preventing websocket issues
@@ -25,10 +28,10 @@ process.on('uncaughtException', function (err) {
 
 // Init server
 var app = express(),
-    ws  = ws.createServer();
+    server = http.createServer(app),
+    ws = new WebSocket.Server({ server });
 
 app.set('NODE_PORT',    NODE_PORT);    // server port
-app.set('NODE_PORTWS',  NODE_PORTWS);  // websocket port
 app.set('NATS_MON_URL', NATS_MON_URL); // nats monitoring url
 app.set('WS',           ws);           // websocket server
 
@@ -37,9 +40,8 @@ app.use(require('./routes')(app));   // routes
 app.use(express.static(path.join(APP_PATH, 'public'))); // static file serving
 
 // Start web server
-app.listen(NODE_PORT);
+// server.listen(NODE_PORT);
+server.listen(NODE_PORT, function listening() {
+  console.log('Listening on %d', server.address().port);
+});
 console.log(util.format('Web server listening at %s', NODE_PORT));
-
-// Start ws server
-ws.listen(NODE_PORTWS);
-console.log(util.format('Websocket server listening at %s', NODE_PORTWS));

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "express": "4.15.x",
     "request": "2.80.x",
     "utilex": "3.x.x",
-    "nodejs-websocket": "1.7.x"
+    "ws": "^3.0.0"
   },
   "devDependencies": {
     "chai": "3.5.x",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -14,12 +14,14 @@ var app = function app() {
 
   // Init server
   var serverURL    = location.protocol + '//' + location.hostname + ':' + location.port,
-      serverCharts = {};
+      serverCharts = {},
+      wsProtocol = "ws:";
 
-  // Init websocket
-  var wsHostname = location.hostname,
-      wsPort     = parseInt(location.port) + 1,
-      wsUrl      = 'ws://' + wsHostname + ':' + wsPort,
+  if (window.location.protocol == "https:") {
+      wsProtocol = "wss:";
+  }
+
+  var wsUrl      = wsProtocol + location.hostname + ':' + location.port + '/ws',
       wsConn     = new WebSocket(wsUrl);
 
   // Handler for open event


### PR DESCRIPTION
This change runs the websocket server on the same port as the http server.
This allows things to work better behind a proxy.

I also changes the data sending code a bit, I had some issues where the loop got broken due to a raised timeout exception. 